### PR TITLE
feat: add cronjob to `employment-hero-app` chart

### DIFF
--- a/employment-hero-app/templates/cronjob.yaml
+++ b/employment-hero-app/templates/cronjob.yaml
@@ -1,5 +1,5 @@
 {{- range $job_name, $job := .Values.app.cron_jobs }}
-{{- $cron_job_app_name := (printf "%s-cronjob-%s" $.Values.app.name $job_name) | snakecase | replace "_" "-" -}}
+{{- $cron_job_app_name := (printf "%s-cronjob-%s" $.Values.app.name $job_name) | replace "_" "-" -}}
 ---
 apiVersion: batch/v2alpha1
 kind: CronJob
@@ -19,6 +19,10 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+          - name: "kubestore"
+            secret:
+              secretName: "{{ $.Values.app.name }}-files"
           containers:
           - name: {{ $cron_job_app_name }}
             {{- if $.Values.files }}

--- a/employment-hero-app/templates/cronjob.yaml
+++ b/employment-hero-app/templates/cronjob.yaml
@@ -1,0 +1,39 @@
+{{- range $job_name, $job := .Values.app.cron_jobs }}
+{{- $cron_job_app_name := (printf "%s-cronjob-%s" $.Values.app.name $job_name) | snakecase | replace "_" "-" -}}
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: {{ $cron_job_app_name }}
+  labels:
+    app: {{ $cron_job_app_name }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+spec:
+  schedule: {{ index $job "schedule" | quote}}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ default 3 $.Values.config.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 3 $.Values.config.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{ $cron_job_app_name }}
+            {{- if $.Values.files }}
+            volumeMounts:
+            - name: "kubestore"
+              mountPath: "/etc/kubestore"
+              readOnly: true
+            {{- end }}
+            resources:
+              requests:
+                cpu: "{{ $.Values.config.cpu_request }}"
+                memory: "{{ $.Values.config.memory_request }}"
+            {{- include "image_labels" $ | indent 12 }}
+            {{- include "env_labels" $ | indent 12 }}
+            {{- include "command_labels" (index $job "command") | indent 12 }}
+          restartPolicy: OnFailure
+...{{ "\n" }}
+{{- end }}

--- a/employment-hero-app/values.yaml
+++ b/employment-hero-app/values.yaml
@@ -51,6 +51,18 @@ app:
     #will_not_be_included:
     #rpc: ["bundle", "exec", "xxx"]
 
+  # Uncomment if you want to add cron job containers
+  # cron_jobs:
+  #   say_hello:
+  #     schedule: "*/1 * * * *"
+  #     command: ["/bin/sh", "-c", "echo hello world \\($(date)\\)"]
+  #   run_task_1:
+  #     schedule: "*/1 * * * *"
+  #     command: ["/bin/sh", "-c", "bundle exec rake eh:do_something"]
+  #   run_task_2:
+  #     schedule: "*/1 * * * *"
+  #     command: ["bundle", "exec", "rake", "eh:do_something"]
+
   job_deadline: 120 # 2 mins
 
   job_restart_policy: OnFailure


### PR DESCRIPTION
This PR is to add cronjob config to employment-hero-app. 

Currently we use concurrencyPolicy=Forbid. But in my opinion, we need to review the cronjob implementation by development teams and monitor to determine what concurrencyPolicy is suitable for each cronjob implementation.